### PR TITLE
Navigate in time using keyboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# IntelliJ project files
+/.idea/*
+*.iml
+/opendataviewerV2.iml

--- a/index.html
+++ b/index.html
@@ -146,18 +146,18 @@
 			}).fitBounds(bounds);
 		}
 
-		function getLastUpdate(url) {
+		function drawMap(context, url) {
 			return fetch(url)
 					.then(function(response) {
 						return response.json();
 					})
 					.then(function(dataAsJson) {
 						var lastUpdateParams = setLastUpdateParams(dataAsJson);
-						filterOnProvidedRegion(params.region, lastUpdateParams);
-						setupMap(lastUpdateParams);
+						filterOnProvidedRegion(context.params.region, lastUpdateParams);
+						setupMap(context, lastUpdateParams);
 					}).catch(function() {
 						console.error("Error while getting the time with lastupdate.");
-						setupMap(getDefaultLastUpdateParameters());
+						setupMap(context, getDefaultLastUpdateParameters());
 					});
 		}
 
@@ -219,21 +219,11 @@
 			request.send();
 		}
 
-		var providedParams = getProvidedUrlParameters();
-		//Fill params with the providedParams if those are valid
-		var params = setParams(providedParams);
-		//load translations
-		var langParams = getLanguageSpecificParameters(params.lang);
+    function setupMap(context, lastUpdateParams){
 
-		//Set initial translations
-		$("span#lastUpdatePreText").text(langParams.lastUpdatePreText);
-		$("span#lastUpdate").text(langParams.lastUpdateDateTimeText[params.interval]);
-		setShowTimeText(langParams.lastUpdateInitialChangeTime[params.interval]);
-
-		var urlForLastUpdate = getUrlToGetLastUpdate(params.interval, params.resolution);
-		getLastUpdate(urlForLastUpdate);
-
-    function setupMap(lastUpdateParams){
+      // Unpack parameters from context.
+      var params = context.params;
+      var langParams = context.langParams;
 
       var showTime = timeFormats.showTimeFunction[params.interval](lastUpdateParams.lastupdate);
       moment.locale(langParams.momentLocale);
@@ -421,31 +411,67 @@
       // Saving original time for use of displaying the forwardHour button
       var originalTime = timeFormats.showTimeFunction[params.interval](lastUpdateParams.lastupdate);
 
-			$('#backHour').click(function(){
-				var changeUnit = timeFormats.changeDateTime[params.interval];
-				var changeTimeFormat = timeFormats.changeDateTimeFormat[params.interval];
-				showTime = moment(showTime).subtract(1, changeUnit).toISOString();
+      function navigatePreviousHour() {
 
-				if (originalTime !== showTime) {
-					$('#forwardHour').css("display", "inline");
-				}
-				var showTimeText = moment(showTime).format(changeTimeFormat); //showTime already subtracted
+		var changeUnit = timeFormats.changeDateTime[params.interval];
+		var changeTimeFormat = timeFormats.changeDateTimeFormat[params.interval];
+		showTime = moment(showTime).subtract(1, changeUnit).toISOString();
 
-        updateMapForTimeChange(showTime, showTimeText);
+		if (originalTime !== showTime) {
+			$('#forwardHour').css("display", "inline");
+		}
+		var showTimeText = moment(showTime).format(changeTimeFormat); //showTime already subtracted
+
+		updateMapForTimeChange(showTime, showTimeText);
+      }
+
+      function navigateNextHour() {
+
+		var changeUnit = timeFormats.changeDateTime[params.interval];
+		var changeTimeFormat = timeFormats.changeDateTimeFormat[params.interval];
+		showTime = moment(showTime).add(1, changeUnit).toISOString();
+
+		if (originalTime === showTime) {
+			$('#forwardHour').css("display", "none");
+		}
+		var showTimeText = moment(showTime).format(changeTimeFormat);
+
+		updateMapForTimeChange(showTime, showTimeText);
+      }
+
+	  $('#backHour').click(function(){
+	  	navigatePreviousHour();
       });
       $('#forwardHour').click(function(){
-				var changeUnit = timeFormats.changeDateTime[params.interval];
-				var changeTimeFormat = timeFormats.changeDateTimeFormat[params.interval];
-				showTime = moment(showTime).add(1, changeUnit).toISOString();
-
-				if (originalTime === showTime) {
-					$('#forwardHour').css("display", "none");
-				}
-				var showTimeText = moment(showTime).format(changeTimeFormat);
-
-        updateMapForTimeChange(showTime, showTimeText);
+      	navigateNextHour();
       });
     }
+
+    function main() {
+		var providedParams = getProvidedUrlParameters();
+		//Fill params with the providedParams if those are valid
+		var params = setParams(providedParams);
+		//load translations
+		var langParams = getLanguageSpecificParameters(params.lang);
+
+		//Set initial translations
+		$("span#lastUpdatePreText").text(langParams.lastUpdatePreText);
+		$("span#lastUpdate").text(langParams.lastUpdateDateTimeText[params.interval]);
+		setShowTimeText(langParams.lastUpdateInitialChangeTime[params.interval]);
+
+		var urlForLastUpdate = getUrlToGetLastUpdate(params.interval, params.resolution);
+
+		// Make a context object which propagates all parameters throughout the machinery.
+		// TODO: Use OO features in the future.
+		var context = {params: params, langParams: langParams};
+
+		// Render the map.
+		drawMap(context, urlForLastUpdate);
+    }
+
+	$(document).ready(function() {
+		main();
+	});
 
 	</script>
 

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 				<div style="text-align: center; ">
 					<input type="button" id="backHour" value="<<" onclick="" />
 					<span id="showTimeText">change time</span>
-					<input type="button" id="forwardHour" value=">>" onclick="" />
+					<input type="button" id="forwardHour" value=">>" onclick="" style="display:none" />
 				</div>
 			</div>
 		</div>
@@ -418,10 +418,17 @@
 				setShowTimeText(showTimeTextValue);
       }
 
+      // Saving original time for use of displaying the forwardHour button
+      var originalTime = timeFormats.showTimeFunction[params.interval](lastUpdateParams.lastupdate);
+
 			$('#backHour').click(function(){
 				var changeUnit = timeFormats.changeDateTime[params.interval];
 				var changeTimeFormat = timeFormats.changeDateTimeFormat[params.interval];
 				showTime = moment(showTime).subtract(1, changeUnit).toISOString();
+
+				if (originalTime !== showTime) {
+					$('#forwardHour').css("display", "inline");
+				}
 				var showTimeText = moment(showTime).format(changeTimeFormat); //showTime already subtracted
 
         updateMapForTimeChange(showTime, showTimeText);
@@ -430,6 +437,10 @@
 				var changeUnit = timeFormats.changeDateTime[params.interval];
 				var changeTimeFormat = timeFormats.changeDateTimeFormat[params.interval];
 				showTime = moment(showTime).add(1, changeUnit).toISOString();
+
+				if (originalTime === showTime) {
+					$('#forwardHour').css("display", "none");
+				}
 				var showTimeText = moment(showTime).format(changeTimeFormat);
 
         updateMapForTimeChange(showTime, showTimeText);

--- a/index.html
+++ b/index.html
@@ -153,6 +153,7 @@
 					})
 					.then(function(dataAsJson) {
 						var lastUpdateParams = setLastUpdateParams(dataAsJson);
+						filterOnProvidedRegion(params.region, lastUpdateParams);
 						setupMap(lastUpdateParams);
 					}).catch(function() {
 						console.error("Error while getting the time with lastupdate.");
@@ -275,7 +276,7 @@
 			var GeoSearchControl = window.GeoSearch.GeoSearchControl;
 			var OpenStreetMapProvider = window.GeoSearch.OpenStreetMapProvider;
 
-			var provider = new OpenStreetMapProvider({ params: { countrycodes: 'be' }, });
+			var provider = new OpenStreetMapProvider({ params: { countrycodes: 'be' } });
 			var searchControl = new GeoSearchControl({
 			  provider: provider,
 				autoComplete: true,

--- a/index.html
+++ b/index.html
@@ -132,6 +132,8 @@
 		}
 
 		function createLeafletMap(parameters, maxZoomLevel) {
+			var bounds = getRegionBounds(parameters.region);
+
 			return L.map('map', {
 				center: [parameters.lat || 50.51, parameters.long || 4.5],
 				minZoom: 7,
@@ -141,7 +143,7 @@
 					pseudoFullscreen: false // if true, fullscreen to page width and height
 				},
 				attributionControl: false
-			}).fitBounds([[49.5, 3.5], [51.5, 5.5]]);
+			}).fitBounds(bounds);
 		}
 
 		function getLastUpdate(url) {

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 				<div style="text-align: center; ">
 					<input type="button" id="backHour" value="<<" onclick="" />
 					<span id="showTimeText">change time</span>
-					<input type="button" id="forwardHour" value=">>" onclick="" style="display:none" />
+					<input type="button" id="forwardHour" value=">>" onclick="" disabled />
 				</div>
 			</div>
 		</div>
@@ -389,7 +389,15 @@
       /**
        * Update the whole map with controls when the time changes.
        */
-      function updateMapForTimeChange(showTimeValue, showTimeTextValue) {
+
+      // Saving original time for use of displaying the forwardHour button
+      var originalTime = timeFormats.showTimeFunction[params.interval](lastUpdateParams.lastupdate);
+
+      function updateMapForTimeChange(showTimeValue) {
+
+		var timeFormat = timeFormats.changeDateTimeFormat[params.interval];
+		var showTimeTextValue = moment(showTimeValue).format(timeFormat);
+
         interpolatedLayer.setParams({time:showTimeValue});
 
 				if (params.no_stations === 'false') {
@@ -406,45 +414,89 @@
         map.addControl(layerLabelControl);
 				styleLayerLabels(layerInfos);
 				setShowTimeText(showTimeTextValue);
-      }
-
-      // Saving original time for use of displaying the forwardHour button
-      var originalTime = timeFormats.showTimeFunction[params.interval](lastUpdateParams.lastupdate);
-
-      function navigatePreviousHour() {
-
-		var changeUnit = timeFormats.changeDateTime[params.interval];
-		var changeTimeFormat = timeFormats.changeDateTimeFormat[params.interval];
-		showTime = moment(showTime).subtract(1, changeUnit).toISOString();
 
 		if (originalTime !== showTime) {
-			$('#forwardHour').css("display", "inline");
+			$('#forwardHour').prop("disabled", false);
+		} else {
+			$('#forwardHour').prop("disabled", true);
 		}
-		var showTimeText = moment(showTime).format(changeTimeFormat); //showTime already subtracted
-
-		updateMapForTimeChange(showTime, showTimeText);
       }
 
-      function navigateNextHour() {
 
+      // Navigate in time by arbitrary amounts.
+      function navigateTimeBackwards(amount, unit) {
+		showTime = moment(showTime).subtract(amount, unit).toISOString();
+		updateMapForTimeChange(showTime);
+      }
+
+      function navigateTimeForward(amount, unit) {
+		showTime = moment(showTime).add(amount, unit).toISOString();
+		updateMapForTimeChange(showTime);
+      }
+
+      // Navigate in time by a single amount of the selected resolution in "params.interval".
+	  function timestepBackwards() {
 		var changeUnit = timeFormats.changeDateTime[params.interval];
-		var changeTimeFormat = timeFormats.changeDateTimeFormat[params.interval];
-		showTime = moment(showTime).add(1, changeUnit).toISOString();
+		navigateTimeBackwards(1, changeUnit);
+	  }
 
-		if (originalTime === showTime) {
-			$('#forwardHour').css("display", "none");
+	  function timestepForward() {
+		var changeUnit = timeFormats.changeDateTime[params.interval];
+		navigateTimeForward(1, changeUnit);
+	  }
+
+
+      // Install mouse- and keyboard event handlers for navigating within the time domain.
+
+	  $('#backHour').click(function() {
+	  	timestepBackwards();
+      });
+      $('#forwardHour').click(function() {
+      	timestepForward();
+      });
+
+	  $(document).keydown(function(event) {
+
+		// Debugging
+		/*
+		var key = {
+			keyCode: event.keyCode, key: event.key,
+			shift: event.shiftKey, alt: event.altKey, ctrl: event.ctrlKey, meta: event.metaKey,
+		};
+		console.log("Handler for .keydown() called:", key);
+		*/
+
+		switch (event.keyCode) {
+
+			case 37:
+				event.preventDefault();
+				if (event.shiftKey && event.altKey) {
+					navigateTimeBackwards(1, 'month');
+				} else if (event.altKey) {
+					navigateTimeBackwards(1, 'week');
+				} else if (event.shiftKey) {
+					navigateTimeBackwards(1, 'days');
+				} else {
+				  	timestepBackwards();
+				}
+				break;
+
+			case 39:
+				event.preventDefault();
+				if (event.shiftKey && event.altKey) {
+					navigateTimeForward(1, 'month');
+				} else if (event.altKey) {
+					navigateTimeForward(1, 'week');
+				} else if (event.shiftKey) {
+					navigateTimeForward(1, 'days');
+				} else {
+			      	timestepForward();
+				}
+				break;
+
 		}
-		var showTimeText = moment(showTime).format(changeTimeFormat);
 
-		updateMapForTimeChange(showTime, showTimeText);
-      }
-
-	  $('#backHour').click(function(){
-	  	navigatePreviousHour();
-      });
-      $('#forwardHour').click(function(){
-      	navigateNextHour();
-      });
+	  });
     }
 
     function main() {

--- a/js/parameters.js
+++ b/js/parameters.js
@@ -103,8 +103,9 @@ function getRegionBounds(region) {
     case "vl": return [[50.688,2.545],[51.505,5.911]];
     // Wallonia
     case "wl": return [[49.497,2.842],[50.812,6.408]];
+    // Brussels
+    case "br": return [[50.73,4.21],[50.936,4.56]];
     // Belgium
-    case "br":
     case "":
     default: return [[49.5, 3.5], [51.5, 5.5]];
   }

--- a/js/parameters.js
+++ b/js/parameters.js
@@ -97,6 +97,19 @@ function getLanguageSpecificParameters(language) {
   }
 }
 
+function getRegionBounds(region) {
+  switch (region) {
+    // Flanders
+    case "vl": return [[50.688,2.545],[51.505,5.911]];
+    // Wallonia
+    case "wl": return [[49.497,2.842],[50.812,6.408]];
+    // Belgium
+    case "br":
+    case "":
+    default: return [[49.5, 3.5], [51.5, 5.5]];
+  }
+}
+
 function getDefaultLastUpdateParameters(){
   return {
     lastupdate: moment().format('YYYY'),

--- a/js/parameters.js
+++ b/js/parameters.js
@@ -30,7 +30,7 @@ function getAllParameterValues(){
     interval: ["hmean","24hmean","8hmean","maxhmean","max8hmean","dmean","anmean","19thmaxhmean"],
     resolution: ["atmostreet","rioifdm","rio4x4","rio1x1"],
     region:["","vl","br","wl"],
-    zoom:[],
+    zoom:[]
   }
 }
 
@@ -220,4 +220,19 @@ function setLastUpdateParams(providedLastUpdateParameters) {
     }
   }
   return lastUpdateParamResult;
+}
+
+function filterOnProvidedRegion(providedRegion, lastUpdateParams) {
+  switch (providedRegion) {
+  case 'vl':
+    lastUpdateParams.cql_filter.network = 'Flanders';
+    break;
+  case 'wl':
+    lastUpdateParams.cql_filter.network = 'Wallonia';
+    break;
+  case 'br':
+  case '':
+  default:
+      // Currently no filter for Brussels or Belgium
+  }
 }

--- a/js/url.js
+++ b/js/url.js
@@ -66,6 +66,11 @@ function getInterpolatedLayerName(parameters) {
   }
   var workspaceName = getWorkspace(parameters.resolution);
   var layerName = workspaceName + ":" + nameParameters.join("_");
-  //Add region if necessary
-  return  parameters.region === "" ? layerName : layerName + "_" + parameters.region;
+
+  //Add region if necessary (not for Belgium and currently also not for Brussels)
+  if (parameters.region === "" || parameters.region === "br") {
+    return layerName;
+  } else {
+    return layerName + "_" + parameters.region;
+  }
 }


### PR DESCRIPTION
Dear @opeeters, @d-roet and @stevenvdbosch.

## Introduction
In order to familiarize ourselves with the code base, we tried to implement a specific feature based on #6. Again, some refactoring happened with respect to the time navigation API introduced previously. The new API functions are called `navigateTimeBackwards()` and `navigateTimeForward()`.

## About
The update improves usability when exploring the data through the time domain. The user is now able to navigate forward and backwards in time by using the arrow left/right keys.

## Details
While the default is to navigate by a single amount of the selected resolution (changeUnit), holding down the shift and alt key or both expands that delta.

- n/a: One hour.
- Shift: One day.
- Alt: One week.
- Shift+Alt: One month.

## Evaluation
By stepping back and forth in fixed intervals, the user can easily compare air quality situations between subsequent days, weeks and months on the same hour. Exploring the data through this lens is really convenient and way more efficient than any visual timepicker will permit.

With kind regards,
Andreas.

cc @wetterfrosch
